### PR TITLE
Scala upgrade 3.5.x

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,7 @@ lazy val root = (project in file("."))
   )
   .settings(
     // these options make 3.5.0 use the given resolution algorithms planned for 3.7.x.
-    scalacOptions ++= List("-source:future-migration", "-language:experimental.modularity"),
+    scalacOptions ++= List("-source:future", "-language:experimental.modularity"),
     Compile / paradoxMaterialTheme := {
       ParadoxMaterialTheme()
     },

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 name := "TDA4j"
 organization := "org.appliedtopology"
 version := "0.1.0-alpha"
-scalaVersion := "3.3.0"
+scalaVersion := "3.5.0"
 
 versionScheme := Some("semver-spec")
 
@@ -36,6 +36,8 @@ lazy val root = (project in file("."))
     GitHubPagesPlugin
   )
   .settings(
+    // these options make 3.5.0 use the given resolution algorithms planned for 3.7.x.
+    scalacOptions ++= List("-source:future-migration", "-language:experimental.modularity"),
     Compile / paradoxMaterialTheme := {
       ParadoxMaterialTheme()
     },

--- a/src/main/scala/org/appliedtopology/tda4j/Chain.scala
+++ b/src/main/scala/org/appliedtopology/tda4j/Chain.scala
@@ -4,7 +4,7 @@ import collection.immutable.SortedMap
 import math.Ordering.Implicits.sortedSetOrdering
 import scala.annotation.{tailrec, targetName}
 import scala.collection.mutable
-
+import math.Fractional.Implicits.infixFractionalOps
 
 /**
  * Typeclass for having a boundary map
@@ -94,7 +94,7 @@ class Chain[CellT : OrderedCell, CoefficientT : Fractional] private[tda4j] (
   def items: Seq[(CellT, CoefficientT)] = entries.toSeq
 
   /** WARNING - this is potentially an expensive operation
-    */
+   */
   override def equals(obj: Any): Boolean = obj match {
     case other: Chain[CellT, CoefficientT] =>
       collapseAll()
@@ -106,6 +106,19 @@ class Chain[CellT : OrderedCell, CoefficientT : Fractional] private[tda4j] (
   override def toString: String =
     if (entries.iterator.isEmpty) "Chain()"
     else entries.iterator.map((c, x) => s"${x.toString}⊠${c.toString}").mkString(" + ")
+
+  def chainBoundary: Chain[CellT, CoefficientT] =
+    Chain.from(entries
+      .iterator
+      .flatMap { (cellO, coeffO) =>
+        cellO
+          .boundary[CoefficientT]
+          .entries
+          .iterator
+          .map { (cellI, coeffI) => (cellI, coeffO * coeffI) }
+      }
+      .toSeq
+    )
 }
 
 object Chain {

--- a/src/main/scala/org/appliedtopology/tda4j/Chain.scala
+++ b/src/main/scala/org/appliedtopology/tda4j/Chain.scala
@@ -137,7 +137,7 @@ object Chain {
 class ChainOps[CellT : OrderedCell, CoefficientT](using fr: Fractional[CoefficientT])
     extends RingModule[Chain[CellT, CoefficientT], CoefficientT] {
 
-  import Numeric.Implicits._
+  import Numeric.Implicits.*
 
   override val zero: Chain[CellT, CoefficientT] = Chain()
 

--- a/src/main/scala/org/appliedtopology/tda4j/Cube.scala
+++ b/src/main/scala/org/appliedtopology/tda4j/Cube.scala
@@ -20,7 +20,7 @@ case class FullInterval(n: Int) extends ElementaryInterval {
   override def toString: String = s"[$n,${n + 1}]"
 }
 
-given OrderedCell[ElementaryInterval] with {
+given ElementaryInterval is OrderedCell with {
   extension (t: ElementaryInterval)
     override def boundary[CoefficientT: Fractional]: Chain[ElementaryInterval, CoefficientT] = t match
       case DegenerateInterval(n) => Chain()
@@ -31,7 +31,7 @@ given OrderedCell[ElementaryInterval] with {
       case DegenerateInterval(n) => 0
       case FullInterval(n) => 1
 
-  override def compare(x: ElementaryInterval, y: ElementaryInterval): Int = elementaryIntervalOrdering.compare(x,y)
+  def compare(x: ElementaryInterval, y: ElementaryInterval): Int = elementaryIntervalOrdering.compare(x,y)
 }
 
 case class ElementaryCube(val intervals: List[ElementaryInterval]) {
@@ -99,14 +99,14 @@ case class ElementaryCube(val intervals: List[ElementaryInterval]) {
 
 given elementaryCubeOrdering : Ordering[ElementaryCube] = Ordering.by(c => c.intervals)
 
-given OrderedCell[ElementaryCube] with {
+given ElementaryCube is OrderedCell with {
   extension (t: ElementaryCube)
     override def boundary[CoefficientT: Fractional]: Chain[ElementaryCube, CoefficientT] =
       t.boundaryImpl
   extension (t: ElementaryCube)
     override def dim: Int = t.intervals.map(_.dim).sum
 
-  override def compare(x: ElementaryCube, y: ElementaryCube): Int = elementaryCubeOrdering.compare(x,y)
+  def compare(x: ElementaryCube, y: ElementaryCube): Int = elementaryCubeOrdering.compare(x,y)
 }
 
 trait CubeStream[FiltrationT: Ordering] extends CellStream[ElementaryCube, FiltrationT]

--- a/src/main/scala/org/appliedtopology/tda4j/FiniteMetricSpace.scala
+++ b/src/main/scala/org/appliedtopology/tda4j/FiniteMetricSpace.scala
@@ -3,7 +3,7 @@ package org.appliedtopology.tda4j
 import math.{pow, sqrt}
 import collection.immutable.Range
 import util.chaining.scalaUtilChainingOps
-import math.Ordering.Implicits._
+import math.Ordering.Implicits.*
 
 /** Interface for being a finite metric space
   *

--- a/src/main/scala/org/appliedtopology/tda4j/Homology.scala
+++ b/src/main/scala/org/appliedtopology/tda4j/Homology.scala
@@ -13,7 +13,7 @@ class SimplicialHomologyContext[VertexT: Ordering, CoefficientT: Fractional, Fil
 
 class CellularHomologyContext[CellT : OrderedCell, CoefficientT: Fractional, FiltrationT: Ordering] extends ChainOps[CellT, CoefficientT]() {
 
-  import barcode._
+  import barcode.*
 
   case class HomologyState(
     cycles: mutable.Map[CellT, Chain[CellT, CoefficientT]],
@@ -43,12 +43,7 @@ class CellularHomologyContext[CellT : OrderedCell, CoefficientT: Fractional, Fil
     ): List[(Int, FiltrationT, FiltrationT)] = {
       advanceTo(f)
       (for
-        (dim, lower, oldUpper, cycle): (
-          Int,
-          FiltrationT,
-          FiltrationT,
-          Chain[CellT, CoefficientT]
-        ) <- barcode.toList
+        (dim : Int, lower : FiltrationT, oldUpper : FiltrationT, cycle : Chain[CellT, CoefficientT]) <- barcode.toList
         if lower <= f
         upper = oldUpper.min(f)
       yield (dim, lower, upper)) ++ (

--- a/src/main/scala/org/appliedtopology/tda4j/Simplex.scala
+++ b/src/main/scala/org/appliedtopology/tda4j/Simplex.scala
@@ -21,11 +21,6 @@ import math.Ordering.Implicits.sortedSetOrdering
  * Vertex type
  */
 case class Simplex[VertexT : Ordering] private[tda4j] (vertices : SortedSet[VertexT]) {
-  override def equals(obj: Any): Boolean = obj match {
-    case other : Simplex[VertexT] => vertices == other.vertices
-    case _ => super.equals(obj)
-  }
-
   override def toString(): String =
     vertices.mkString(s"∆(", ",", ")")
 

--- a/src/main/scala/org/appliedtopology/tda4j/Simplex.scala
+++ b/src/main/scala/org/appliedtopology/tda4j/Simplex.scala
@@ -20,7 +20,7 @@ import math.Ordering.Implicits.sortedSetOrdering
  * @tparam VertexT
  * Vertex type
  */
-case class Simplex[VertexT : Ordering] private (vertices : SortedSet[VertexT]) {
+case class Simplex[VertexT : Ordering] private[tda4j] (vertices : SortedSet[VertexT]) {
   override def equals(obj: Any): Boolean = obj match {
     case other : Simplex[VertexT] => vertices == other.vertices
     case _ => super.equals(obj)
@@ -40,7 +40,7 @@ given [VertexT : Ordering] => Ordering[Simplex[VertexT]] = simplexOrdering
 
   //  Ordering.by{(spx: Simplex[VertexT]) => spx.vertices}(sortedSetOrdering[SortedSet, VertexT](vtxOrdering))
 
-given [VertexT : Ordering] : OrderedCell[Simplex[VertexT]] with {
+given [VertexT : Ordering] => Simplex[VertexT] is OrderedCell with {
   given Ordering[Simplex[VertexT]] = simplexOrdering
   extension (t: Simplex[VertexT]) {
     override def boundary[CoefficientT](using fr: Fractional[CoefficientT]): Chain[Simplex[VertexT], CoefficientT] =
@@ -54,7 +54,7 @@ given [VertexT : Ordering] : OrderedCell[Simplex[VertexT]] with {
       )
     override def dim: Int = t.vertices.size - 1
   }
-  override def compare(x: Simplex[VertexT], y: Simplex[VertexT]): Int = simplexOrdering[VertexT].compare(x,y)
+  def compare(x: Simplex[VertexT], y: Simplex[VertexT]): Int = simplexOrdering[VertexT].compare(x,y)
 }
 
 /** Simplex companion object with factory methods

--- a/src/main/scala/org/appliedtopology/tda4j/Simplex.scala
+++ b/src/main/scala/org/appliedtopology/tda4j/Simplex.scala
@@ -6,9 +6,6 @@ import scala.math.Ordering.IntOrdering
 import scala.math.Ordering.Double.IeeeOrdering
 import math.Ordering.Implicits.sortedSetOrdering
 
-given simplexOrdering[VertexT: Ordering]: Ordering[Simplex[VertexT]] =
-  Ordering.by{(spx:Simplex[VertexT]) => spx.vertices}(sortedSetOrdering[SortedSet, VertexT])
-
 /** Class representing an abstract simplex. Abstract simplices are given by sets (of totally ordered vertices)
  * and inherit from `Cell` so that the class has a `boundary` and a `dim` method.
  *
@@ -35,6 +32,13 @@ case class Simplex[VertexT : Ordering] private (vertices : SortedSet[VertexT]) {
   def union(other: Simplex[VertexT]) =
     new Simplex(vertices.union(other.vertices))
 }
+
+def simplexOrdering[VertexT : Ordering as vtxOrdering]: Ordering[Simplex[VertexT]] =
+  Ordering.by{(spx: Simplex[VertexT]) => spx.vertices}(sortedSetOrdering[SortedSet, VertexT](vtxOrdering))
+
+given [VertexT : Ordering] => Ordering[Simplex[VertexT]] = simplexOrdering
+
+  //  Ordering.by{(spx: Simplex[VertexT]) => spx.vertices}(sortedSetOrdering[SortedSet, VertexT](vtxOrdering))
 
 given [VertexT : Ordering] : OrderedCell[Simplex[VertexT]] with {
   given Ordering[Simplex[VertexT]] = simplexOrdering

--- a/src/main/scala/org/appliedtopology/tda4j/SimplicialSet.scala
+++ b/src/main/scala/org/appliedtopology/tda4j/SimplicialSet.scala
@@ -31,8 +31,8 @@ object SimplicialSetElement {
     override def degeneracies: List[Int] = List.empty
 }
 
-given HasDimension[SimplicialSetElement] with {
-  extension (t: SimplicialSetElement) override def dim = t.dimension
+given SimplicialSetElement is HasDimension with {
+  extension (t: SimplicialSetElement) def dim = t.dimension
 }
 
 /**
@@ -178,7 +178,7 @@ trait SimplicialSet {
   given sseOrdering: Ordering[SimplicialSetElement] =
     Ordering.by((sse: SimplicialSetElement) => sse.dim).orElseBy(_.hashCode())
 
-  given normalizedHomologyCell(using seOrd: Ordering[SimplicialSetElement])(using hasDim: HasDimension[SimplicialSetElement]): OrderedCell[SimplicialSetElement] with {
+  given normalizedHomologyCell(using seOrd: Ordering[SimplicialSetElement])(using hasDim: SimplicialSetElement is HasDimension): (SimplicialSetElement is OrderedCell) with {
     extension (t: SimplicialSetElement) {
       override def boundary[CoefficientT](using
                                           fr: Fractional[CoefficientT]
@@ -199,7 +199,7 @@ trait SimplicialSet {
       override def dim: Int = hasDim.dim(t.base) + t.degeneracies.size
     }
 
-    override def compare(x: SimplicialSetElement, y: SimplicialSetElement): Int =
+    def compare(x: SimplicialSetElement, y: SimplicialSetElement): Int =
       seOrd.compare(x, y)
   }
 
@@ -424,7 +424,7 @@ def normalizedCellStream[FiltrationT: Ordering : Filterable](
     }
     .orElseBy(_.dim)
 
-  given sseCell: Cell[SimplicialSetElement] = ss.normalizedHomologyCell
+  given sseCell: (SimplicialSetElement is OrderedCell) = ss.normalizedHomologyCell
 
   new CellStream[SimplicialSetElement, FiltrationT] {
     export filterable.{largest, smallest}
@@ -518,7 +518,7 @@ case class Product(left: SimplicialSet, right: SimplicialSet) extends Simplicial
       .by((pe: ProductElement) => pe.left)(left.sseOrdering)
       .orElseBy((pe: ProductElement) => pe.right)(right.sseOrdering)
 
-  given productCell: OrderedCell[ProductElement] with {
+  given productCell: (ProductElement is OrderedCell) with {
     extension (t: ProductElement)
       override def boundary[CoefficientT: Fractional]: Chain[ProductElement, CoefficientT] = {
         val leftBoundary: Chain[SimplicialSetElement, CoefficientT] = {
@@ -538,7 +538,7 @@ case class Product(left: SimplicialSet, right: SimplicialSet) extends Simplicial
 
     extension (t: ProductElement) override def dim: Int = t.left.dim
 
-    override def compare(x: ProductElement, y: ProductElement): Int =
+    def compare(x: ProductElement, y: ProductElement): Int =
       productOrdering.compare(x, y)
   }
 

--- a/src/main/scala/org/appliedtopology/tda4j/SimplicialSet.scala
+++ b/src/main/scala/org/appliedtopology/tda4j/SimplicialSet.scala
@@ -418,13 +418,13 @@ def normalizedCellStream[FiltrationT: Ordering : Filterable](
     filterable.smallest
   })
 
-  given sseCell: Cell[SimplicialSetElement] = ss.normalizedHomologyCell
-
   given sseOrd: Ordering[SimplicialSetElement] = Ordering
     .by[SimplicialSetElement, FiltrationT] { (sse: SimplicialSetElement) =>
       filtrationValues.applyOrElse(sse, { _ => filterable.smallest })
     }
     .orElseBy(_.dim)
+
+  given sseCell: Cell[SimplicialSetElement] = ss.normalizedHomologyCell
 
   new CellStream[SimplicialSetElement, FiltrationT] {
     export filterable.{largest, smallest}

--- a/src/main/scala/org/appliedtopology/tda4j/SimplicialSet.scala
+++ b/src/main/scala/org/appliedtopology/tda4j/SimplicialSet.scala
@@ -172,7 +172,7 @@ trait SimplicialSet {
       val generators: Seq[SimplicialSetElement] = this.generators.takeWhile(_.dim <= n)
 
       override def face(index: Int): PartialFunction[SimplicialSetElement, SimplicialSetElement] =
-        this.face(index)
+        ??? // FIXME this.face(index) creates an infinite loop - but how else can we access the existing face method? /MVJ
     }
 
   given sseOrdering: Ordering[SimplicialSetElement] =

--- a/src/main/scala/org/appliedtopology/tda4j/SimplicialSet.scala
+++ b/src/main/scala/org/appliedtopology/tda4j/SimplicialSet.scala
@@ -13,8 +13,11 @@ import scala.math.Fractional.Implicits.infixFractionalOps
  */
 trait SimplicialSetElement {
   def base: SimplicialSetElement
+
   def dimension: Int
+
   def degeneracies: List[Int]
+
   override def toString: String = unicode.unicodeSuperScript(s"∆$dimension")
 }
 
@@ -22,11 +25,13 @@ object SimplicialSetElement {
   object empty extends SimplicialSetElement:
     sse =>
     override def base: SimplicialSetElement = sse
+
     override def dimension: Int = -1
+
     override def degeneracies: List[Int] = List.empty
 }
 
-given HasDimension[SimplicialSetElement] with { 
+given HasDimension[SimplicialSetElement] with {
   extension (t: SimplicialSetElement) override def dim = t.dimension
 }
 
@@ -41,7 +46,9 @@ given HasDimension[SimplicialSetElement] with {
 def simplicialGenerator(generatorDim: Int): SimplicialSetElement =
   new SimplicialSetElement:
     override def base: SimplicialSetElement = this
+
     override def dimension: Int = generatorDim
+
     override def degeneracies: List[Int] = List.empty
 
 /**
@@ -52,9 +59,11 @@ def simplicialGenerator(generatorDim: Int): SimplicialSetElement =
  * @param hasDimension$T$0
  * @tparam T
  */
-case class SimplicialWrapper[T : HasDimension](wrapped: T) extends SimplicialSetElement {
+case class SimplicialWrapper[T: HasDimension](wrapped: T) extends SimplicialSetElement {
   override def base: SimplicialSetElement = this
+
   override def dimension: Int = wrapped.dim
+
   override def degeneracies: List[Int] = List.empty
 
   override def toString: String = s"wrapped[${wrapped}]"
@@ -74,13 +83,15 @@ case class SimplicialWrapper[T : HasDimension](wrapped: T) extends SimplicialSet
  * @param base
  * @param degeneracies
  */
-case class DegenerateSimplicialSetElement private (base: SimplicialSetElement, degeneracies: List[Int])
-    extends SimplicialSetElement:
+case class DegenerateSimplicialSetElement private(base: SimplicialSetElement, degeneracies: List[Int])
+  extends SimplicialSetElement:
   override def dimension: Int = base.dim + degeneracies.size
+
   override def toString: String =
     degeneracies
       .map(d => "s" + unicode.unicodeSubScript(d.toString))
       .mkString("", "  ", " ") + s"${base.toString}"
+
   // Handle cases where the base is also a simplicial set element
   // This is very reminiscent of a monad structure - but the data type is not a data container the way most
   // monads in functional programming would be
@@ -113,10 +124,10 @@ object DegenerateSimplicialSetElement {
  * A simplicial set **must** have:
  *
  * 1. A sequence of generating elements. These are considered non-degenerate in the context of this simplicial set.
- *    This sequence will be assumed to be in increasing order of dimension (so that things like [[nSkeleton]] can
- *    stop searching when it hits large enough dimensions), but this is not structurally enforced by the trait itself.
+ * This sequence will be assumed to be in increasing order of dimension (so that things like [[nSkeleton]] can
+ * stop searching when it hits large enough dimensions), but this is not structurally enforced by the trait itself.
  * 2. For each index $i$, a partial function from [[SimplicialSetElement]] to [[SimplicialSetElement]] encoding
- *    the $i$th face map. These partial functions **must** be defined on all the [[generators]].
+ * the $i$th face map. These partial functions **must** be defined on all the [[generators]].
  *
  * With these building blocks, a simplicial set also has:
  *
@@ -124,18 +135,26 @@ object DegenerateSimplicialSetElement {
  * 2. A method for listing all n-dimensional cells (degenerate as well as non-degenerate).
  * 3. A total order of `SimplicialSetElement`s, as a `given` declaration.
  * 4. An instance of the `Cell` typeclass for `SimplicialSetElement`s, as a `given` declaration.
- *    This instance works on the assumption that you will want to work in the **normalized Moore complex**,
- *    and will treat the [[generators]] as your cells.
+ * This instance works on the assumption that you will want to work in the **normalized Moore complex**,
+ * and will treat the [[generators]] as your cells.
  * 5. Functions to compute an [[f_vector]] (of non-degenerate elements), a full f-vector (of all elements),
- *    and the Euler characteristic.
+ * and the Euler characteristic.
  */
 trait SimplicialSet {
   def generators: Seq[SimplicialSetElement]
+
   def face(index: Int): PartialFunction[SimplicialSetElement, SimplicialSetElement]
 
+  def degenerate(index: Int): PartialFunction[SimplicialSetElement, SimplicialSetElement] = {
+    case sse@DegenerateSimplicialSetElement(base, degeneracies) =>
+      DegenerateSimplicialSetElement(base, DegenerateSimplicialSetElement.normalizeDegeneracies(degeneracies, List(index)))
+    case sse =>
+      DegenerateSimplicialSetElement(sse, List(index))
+  }
 
   def contains(sse: SimplicialSetElement): Boolean =
     generators.exists(g => g.base == sse.base)
+
   infix def ∋(sse: SimplicialSetElement): Boolean = contains(sse)
 
   def all_n_cells(n: Int): List[SimplicialSetElement] =
@@ -158,6 +177,7 @@ trait SimplicialSet {
 
   given sseOrdering: Ordering[SimplicialSetElement] =
     Ordering.by((sse: SimplicialSetElement) => sse.dim).orElseBy(_.hashCode())
+
   given normalizedHomologyCell(using seOrd: Ordering[SimplicialSetElement])(using hasDim: HasDimension[SimplicialSetElement]): OrderedCell[SimplicialSetElement] with {
     extension (t: SimplicialSetElement) {
       override def boundary[CoefficientT](using
@@ -178,6 +198,7 @@ trait SimplicialSet {
         }
       override def dim: Int = hasDim.dim(t.base) + t.degeneracies.size
     }
+
     override def compare(x: SimplicialSetElement, y: SimplicialSetElement): Int =
       seOrd.compare(x, y)
   }
@@ -200,20 +221,23 @@ trait SimplicialSet {
   def eulerCharacteristic(maxDim: Int = 10): Int =
     f_vector(maxDim)
       .zipWithIndex
-      .map{(f,i) => List(1,-1)(i%2) * f}
+      .map { (f, i) => List(1, -1)(i % 2) * f }
       .sum
 }
 
 object SimplicialSet {
-  def mkFaceMaps(faceMapping : PartialFunction[SimplicialSetElement, List[SimplicialSetElement]]):
-    Int => PartialFunction[SimplicialSetElement, SimplicialSetElement] = index => {
-    case sse if (sse.dim <= 0)  => SimplicialSetElement.empty
+  def mkFaceMaps(faceMapping: PartialFunction[SimplicialSetElement, List[SimplicialSetElement]]):
+  Int => PartialFunction[SimplicialSetElement, SimplicialSetElement] = index => {
+    case sse if (sse.dim <= 0) => SimplicialSetElement.empty
     case sse if (0 <= index) && (index <= sse.dim) =>
       val split = sse.degeneracies
         .groupBy(j => (index < j, index == j || index == j + 1, index > j + 1))
         .orElse(_ => List.empty)
+
       inline def INDEX_SMALL = (true, false, false)
+
       inline def INDEX_MATCH = (false, true, false)
+
       inline def INDEX_LARGE = (false, false, true)
 
       val newFace: Option[Int] =
@@ -233,7 +257,7 @@ object SimplicialSet {
           DegenerateSimplicialSetElement(sse.base, newDegeneracies)
         case Some(i) =>
           DegenerateSimplicialSetElement(
-            faceMapping.applyOrElse(sse.base, {(_) => List.empty})(i), 
+            faceMapping.applyOrElse(sse.base, { (_) => List.empty })(i),
             newDegeneracies).join()
       }
   }
@@ -266,13 +290,14 @@ object SimplicialSet {
  * This is an implementation of the [[SimplicialSet]] trait that allows for infinite generating sets.
  * It also assembles face maps for you from just defining them on the generators and inferring their
  * results on degeneracies.
+ *
  * @param generators
  * @param faceMapping
  */
 case class LazySimplicialSet(
-  generators: LazyList[SimplicialSetElement],
-  faceMapping: PartialFunction[SimplicialSetElement, List[SimplicialSetElement]]
-) extends SimplicialSet {
+                              generators: LazyList[SimplicialSetElement],
+                              faceMapping: PartialFunction[SimplicialSetElement, List[SimplicialSetElement]]
+                            ) extends SimplicialSet {
   val faceMaps = SimplicialSet.mkFaceMaps(faceMapping)
 
   override def face(index: Int): PartialFunction[SimplicialSetElement, SimplicialSetElement] =
@@ -281,42 +306,44 @@ case class LazySimplicialSet(
 
 
 /** Notes on boundaries of degenerate elements
-  *
-  * Suppose w = s_j_ z Suppose k > j+1, i < j Then by the simplicial set laws: d_k_ s_j_ z = s_j d_k-1_ z d_i_ s_j_ z =
-  * s_j-1_ d_i_ z d_j_ s_j_ z = d_j+1_ s_j_ z = z
-  *
-  * So from all this follows: ∂ s_j_ z = ∑ (-1)^n^ d_i_ s_j_ z = s_j_ (d_0_ - d_1_ + ... ± d_j-1_) z + (z - z) ± s_j_
-  * (d_j+1_ - d_j+2_ + ... ± d_n_) z = s_j_ ∂ z (??? not sure it all lines up right here?)
-  *
-  * Goerss-Jardine III:2, esp. Theorem 2.1:
-  *
-  * Normalized Chain Complex NA is isomorphic to the quotient A/DA chain complex clearing out the degenerate simplices.
-  */
+ *
+ * Suppose w = s_j_ z Suppose k > j+1, i < j Then by the simplicial set laws: d_k_ s_j_ z = s_j d_k-1_ z d_i_ s_j_ z =
+ * s_j-1_ d_i_ z d_j_ s_j_ z = d_j+1_ s_j_ z = z
+ *
+ * So from all this follows: ∂ s_j_ z = ∑ (-1)^n^ d_i_ s_j_ z = s_j_ (d_0_ - d_1_ + ... ± d_j-1_) z + (z - z) ± s_j_
+ * (d_j+1_ - d_j+2_ + ... ± d_n_) z = s_j_ ∂ z (??? not sure it all lines up right here?)
+ *
+ * Goerss-Jardine III:2, esp. Theorem 2.1:
+ *
+ * Normalized Chain Complex NA is isomorphic to the quotient A/DA chain complex clearing out the degenerate simplices.
+ */
 
 /** Normalization is with respect to simplicial identities:
-  *
-  * Face(i)Face(j) = Face(j-1)Face(i) if i < j Face(i)Degeneracy(j) = Degeneracy(j-1)Face(i) if i < j
-  * Face(i)Degeneracy(j) = Degeneracy(j)Face(i-1) if i > j+1 Face(j)Degeneracy(j) = 1 = Face(j+1)Degeneracy(j)
-  * Degeneracy(i)Degeneracy(j) = Degeneracy(j+1)Degeneracy(j) if i < j+1
-  *
-  * With these identities we can process any sequence of applications of faces and degeneracies until faces in
-  * decreasing order sit to the right (are applied first) and degeneracies are applied on top of these. Since each
-  * nondegenerate simplex must know its faces, we only track degeneracies with a specific list. Now:
-  * Face(i)Degeneracy(j)Degeneracy(k)Degeneracy(l) =
-  * -reduce face index if i > j+1; reduce degeneracy index if i < j Degeneracy(j)Face(i-1)Degeneracy(k)Degeneracy(l) =
-  * ...
-  */
+ *
+ * Face(i)Face(j) = Face(j-1)Face(i) if i < j Face(i)Degeneracy(j) = Degeneracy(j-1)Face(i) if i < j
+ * Face(i)Degeneracy(j) = Degeneracy(j)Face(i-1) if i > j+1 Face(j)Degeneracy(j) = 1 = Face(j+1)Degeneracy(j)
+ * Degeneracy(i)Degeneracy(j) = Degeneracy(j+1)Degeneracy(j) if i < j+1
+ *
+ * With these identities we can process any sequence of applications of faces and degeneracies until faces in
+ * decreasing order sit to the right (are applied first) and degeneracies are applied on top of these. Since each
+ * nondegenerate simplex must know its faces, we only track degeneracies with a specific list. Now:
+ * Face(i)Degeneracy(j)Degeneracy(k)Degeneracy(l) =
+ * -reduce face index if i > j+1; reduce degeneracy index if i < j Degeneracy(j)Face(i-1)Degeneracy(k)Degeneracy(l) =
+ * ...
+ */
 
 /** ************** Constructions
-  */
+ */
 
 import math.Ordering.Implicits.sortedSetOrdering
 
 
-case class SimplicialMap(mapping : PartialFunction[SimplicialSetElement, SimplicialSetElement]) {
+case class SimplicialMap(mapping: PartialFunction[SimplicialSetElement, SimplicialSetElement],
+                         source: SimplicialSet, target: SimplicialSet) {
   def apply(sse: SimplicialSetElement): SimplicialSetElement = sse match {
-    case DegenerateSimplicialSetElement(base, degeneracies) if(mapping.isDefinedAt(base)) =>
+    case DegenerateSimplicialSetElement(base, degeneracies) if (mapping.isDefinedAt(base)) =>
       DegenerateSimplicialSetElement(mapping(base), degeneracies).join()
+    case sse if(mapping.isDefinedAt(sse)) => mapping.apply(sse)
   }
 }
 
@@ -327,7 +354,7 @@ case class SimplicialMap(mapping : PartialFunction[SimplicialSetElement, Simplic
  * @param ordering$VertexT$0
  * @tparam VertexT
  */
-class Singular[VertexT: Ordering] private[tda4j] (val allSimplices: Seq[Simplex[VertexT]]) extends SimplicialSet {
+class Singular[VertexT: Ordering] private[tda4j](val allSimplices: Seq[Simplex[VertexT]]) extends SimplicialSet {
   val generators: Seq[SimplicialWrapper[Simplex[VertexT]]] =
     allSimplices.toSeq.sortBy(_.dim).map(spx => SimplicialWrapper(spx))
   val faceMapping: Map[SimplicialSetElement, List[SimplicialSetElement]] = Map.from(
@@ -342,6 +369,7 @@ class Singular[VertexT: Ordering] private[tda4j] (val allSimplices: Seq[Simplex[
 
   override def face(index: Int): PartialFunction[SimplicialSetElement, SimplicialSetElement] =
     simplicialSet.face(index)
+
   override def contains(sse: SimplicialSetElement): Boolean =
     simplicialSet.contains(sse)
 }
@@ -356,7 +384,7 @@ object Singular {
    * @tparam VertexT
    * @return
    */
-  def from[VertexT : Ordering](underlying : Seq[Simplex[VertexT]]): Singular[VertexT] =
+  def from[VertexT: Ordering](underlying: Seq[Simplex[VertexT]]): Singular[VertexT] =
     fromAll(underlying.toSet.flatMap(spx => spx.vertices.subsets.filter(_.nonEmpty).map(Simplex.from)).toSeq)
 
   /**
@@ -367,7 +395,7 @@ object Singular {
    * @tparam VertexT
    * @return
    */
-  def fromAll[VertexT : Ordering](allSimplices : Seq[Simplex[VertexT]]): Singular[VertexT] = new Singular(allSimplices)
+  def fromAll[VertexT: Ordering](allSimplices: Seq[Simplex[VertexT]]): Singular[VertexT] = new Singular(allSimplices)
 }
 
 /**
@@ -380,30 +408,35 @@ object Singular {
  * @tparam FiltrationT
  * @return
  */
-def normalizedCellStream[FiltrationT: Ordering: Filterable](
-                                                             ss: SimplicialSet,
-                                                             filtrationValueO: Option[PartialFunction[SimplicialSetElement, FiltrationT]] = None
-): CellStream[SimplicialSetElement, FiltrationT] = {
+def normalizedCellStream[FiltrationT: Ordering : Filterable](
+                                                              ss: SimplicialSet,
+                                                              filtrationValueO: Option[PartialFunction[SimplicialSetElement, FiltrationT]] = None
+                                                            ): CellStream[SimplicialSetElement, FiltrationT] = {
   val filterable: Filterable[FiltrationT] = summon[Filterable[FiltrationT]]
+
   def filtrationValues = filtrationValueO.getOrElse({ case _ =>
     filterable.smallest
   })
+
   given sseCell: Cell[SimplicialSetElement] = ss.normalizedHomologyCell
+
   given sseOrd: Ordering[SimplicialSetElement] = Ordering
     .by[SimplicialSetElement, FiltrationT] { (sse: SimplicialSetElement) =>
-      filtrationValues.applyOrElse(sse, { _ => filterable.smallest }) }
-    .orElseBy(_.dim)
-  new CellStream[SimplicialSetElement, FiltrationT] {
-      export filterable.{largest, smallest}
-
-      override def filtrationValue: PartialFunction[SimplicialSetElement, FiltrationT] = filtrationValues
-
-      override def filtrationOrdering: Ordering[SimplicialSetElement] = sseOrd
-
-      override def iterator: Iterator[SimplicialSetElement] =
-        ss.generators.sorted(filtrationOrdering).iterator
+      filtrationValues.applyOrElse(sse, { _ => filterable.smallest })
     }
+    .orElseBy(_.dim)
+
+  new CellStream[SimplicialSetElement, FiltrationT] {
+    export filterable.{largest, smallest}
+
+    override def filtrationValue: PartialFunction[SimplicialSetElement, FiltrationT] = filtrationValues
+
+    override def filtrationOrdering: Ordering[SimplicialSetElement] = sseOrd
+
+    override def iterator: Iterator[SimplicialSetElement] =
+      ss.generators.sorted(filtrationOrdering).iterator
   }
+}
 
 /**
  * Helper function to interleave two lazy lists -- so that we can take their union without having to run
@@ -431,21 +464,26 @@ def alternateLazyLists[A](left: Seq[A], right: Seq[A]): LazyList[A] =
  */
 case class Coproduct(left: SimplicialSet, right: SimplicialSet) extends SimplicialSet {
   override def generators: LazyList[SimplicialSetElement] = alternateLazyLists(left.generators, right.generators)
+
   override def face(index: Int): PartialFunction[SimplicialSetElement, SimplicialSetElement] =
     left.face(index).orElse(right.face(index))
+
   override def contains(sse: SimplicialSetElement): Boolean =
     left.contains(sse) || right.contains(sse)
 }
 
 /** For now this is only written for finitely generated simplicial sets.
-  *
-  * Anything with potentially infinite generator sets will need special handling.
-  */
+ *
+ * Anything with potentially infinite generator sets will need special handling.
+ */
 
 case class ProductElement(left: SimplicialSetElement, right: SimplicialSetElement) extends SimplicialSetElement {
   assert(left.dim == right.dim)
+
   override def base: SimplicialSetElement = this
+
   override def dimension: Int = left.dim
+
   override def degeneracies: List[Int] = List()
 
   override def toString: String =
@@ -474,12 +512,12 @@ case class ProductElement(left: SimplicialSetElement, right: SimplicialSetElemen
 // So this should be a valid candidate, but is missed if we just take the sequence (n to(0, -1)) and split it
 
 
-
 case class Product(left: SimplicialSet, right: SimplicialSet) extends SimplicialSet {
   given productOrdering: Ordering[ProductElement] =
     Ordering
       .by((pe: ProductElement) => pe.left)(left.sseOrdering)
       .orElseBy((pe: ProductElement) => pe.right)(right.sseOrdering)
+
   given productCell: OrderedCell[ProductElement] with {
     extension (t: ProductElement)
       override def boundary[CoefficientT: Fractional]: Chain[ProductElement, CoefficientT] = {
@@ -503,10 +541,12 @@ case class Product(left: SimplicialSet, right: SimplicialSet) extends Simplicial
     override def compare(x: ProductElement, y: ProductElement): Int =
       productOrdering.compare(x, y)
   }
+
   val generatorPairs: LazyList[(SimplicialSetElement, SimplicialSetElement)] = LazyList.from(for
     gL <- left.generators
     gR <- right.generators
   yield (gL, gR))
+
   def productGenerators(dimension: Int): LazyList[SimplicialSetElement] =
     generatorPairs
       .filter((gL, gR) => gL.dim + gR.dim >= dimension)
@@ -518,33 +558,43 @@ case class Product(left: SimplicialSet, right: SimplicialSet) extends Simplicial
           comb <- degeneracyIndexPool.combinations(totalCount)
           combL <- comb.combinations(dimension - gL.dim)
           combR = comb diff combL
-          if(combL.reverse.zipWithIndex.forall { (c,i) => c <= gL.dim+i })
-          if(combR.reverse.zipWithIndex.forall { (c,i) => c <= gR.dim+i })
+          if (combL.reverse.zipWithIndex.forall { (c, i) => c <= gL.dim + i })
+          if (combR.reverse.zipWithIndex.forall { (c, i) => c <= gR.dim + i })
         yield
           SimplicialWrapper(ProductElement(
             DegenerateSimplicialSetElement(gL, combL.toList),
             DegenerateSimplicialSetElement(gR, combR.toList)))
       }
+
   val maxdim = (left.generators.map(_.dim).max) + (right.generators.map(_.dim).max)
+
   override def generators: Seq[SimplicialSetElement] =
     (0 to maxdim).flatMap(productGenerators)
+
   override def face(index: Int): PartialFunction[SimplicialSetElement, SimplicialSetElement] = {
     // see e.g. https://ncatlab.org/nlab/show/product+of+simplices#ProductsOfSimplicialSets prop 2.1.
-    case sse if(sse.dim <= 0) => SimplicialSetElement.empty
-    case sse @ SimplicialWrapper(ProductElement(sseL, sseR)) =>
+    case sse if (sse.dim <= 0) => SimplicialSetElement.empty
+    case sse@SimplicialWrapper(ProductElement(sseL, sseR)) =>
       SimplicialWrapper(ProductElement(left.face(index)(sseL), right.face(index)(sseR)))
   }
+
   override def contains(sse: SimplicialSetElement): Boolean =
     generators.contains(sse.base)
 }
 
+case class SubSimplicialSetElement(base: SimplicialSetElement) extends SimplicialSetElement {
+  override def dimension: Int = base.dimension
+  override def degeneracies: List[Int] = List.empty
+}
 case class SubSimplicialSet(
                              subSet: SimplicialSet,
                              ambient: SimplicialSet,
                              inclusion: PartialFunction[SimplicialSetElement, SimplicialSetElement]
-) extends SimplicialSet {
+                           ) extends SimplicialSet {
   override def generators: Seq[SimplicialSetElement] = subSet.generators
+
   override def face(index: Int): PartialFunction[SimplicialSetElement, SimplicialSetElement] = subSet.face(index)
+
   override def contains(sse: SimplicialSetElement): Boolean = subSet.contains(sse)
 }
 
@@ -552,20 +602,27 @@ object SubSimplicialSet {
   def from(ambient: SimplicialSet, generators: Seq[SimplicialSetElement]): SubSimplicialSet =
     SubSimplicialSet(
       SimplicialSet(
-        generators.map(SimplicialWrapper.apply).toList,
+        generators.map(SubSimplicialSetElement.apply).toList,
         Map.from(generators.map { (g) =>
-          SimplicialWrapper(g) -> (if(g.dim > 0)
-              (0 to g.dim)
-                .map { (i) => ambient.face(i)(g) }
-                .map { case DegenerateSimplicialSetElement(base, degeneracies) =>
-                  DegenerateSimplicialSetElement(SimplicialWrapper(base), degeneracies)
-                case sse => DegenerateSimplicialSetElement(sse, List.empty)
-                }
-                .toList
+          SubSimplicialSetElement(g) -> (if (g.dim > 0)
+            (0 to g.dim)
+              .map { (i) => ambient.face(i)(g) }
+              .map { 
+              case DegenerateSimplicialSetElement(base, degeneracies) =>
+                DegenerateSimplicialSetElement(SubSimplicialSetElement(base), degeneracies)
+              case sse => DegenerateSimplicialSetElement(sse, List.empty)
+              }
+              .toList
           else List.empty)
         })),
       ambient,
-      SimplicialWrapper.apply
+      {
+        case sse@DegenerateSimplicialSetElement(base, degeneracies) => base match {
+          case SubSimplicialSetElement(base2) => DegenerateSimplicialSetElement(base2, degeneracies)
+          case _ => sse
+        }
+        case SubSimplicialSetElement(base3) => base3
+      }
     )
 }
 
@@ -576,9 +633,49 @@ case class QuotientSimplicialSet(
                                 ) extends SimplicialSet {
   override def generators: Seq[SimplicialSetElement] = quotientSet.generators
 
-  override def face(index: Int): PartialFunction[SimplicialSetElement, SimplicialSetElement] = ???
+  override def face(index: Int): PartialFunction[SimplicialSetElement, SimplicialSetElement] = quotientSet.face(index)
 
-  override def contains(sse: SimplicialSetElement): Boolean = super.contains(sse)
+  override def contains(sse: SimplicialSetElement): Boolean = quotientSet.contains(sse)
+}
+
+object QuotientSimplicialSet {
+  def from(superSet : SimplicialSet, collapses: Seq[Set[SimplicialSetElement]]): QuotientSimplicialSet = {
+    assert(collapses.forall{ (collapse) => collapse.map(_.dim).toSet.size <= 1}) // homogenous collapse sets
+    val collapseMap : Map[SimplicialSetElement, Set[SimplicialSetElement]] =
+      Map.from(collapses.map { (collapse) => 
+        DegenerateSimplicialSetElement(simplicialGenerator(0), (collapse.head.dim-1 to (0,-1)).toList) -> collapse})
+    val projection : PartialFunction[SimplicialSetElement, SimplicialSetElement] =
+      Map.from(collapseMap.flatMap{(basis, contents) => contents.map(_ -> basis)}).orElse(identity(_))
+    val removed = collapses.flatten
+    val quotientGenerators = superSet.generators
+      .filter(!removed.contains(_)) ++ collapseMap.keys
+    QuotientSimplicialSet(
+      SimplicialSet(quotientGenerators.toList, 
+                    {
+                      case sse@DegenerateSimplicialSetElement(base, degeneracies) =>
+                        if(!collapseMap.keySet.contains(base))
+                          (0 to sse.dim).map(superSet.face(_)(sse)).toList
+                        else
+                          (0 to sse.dim).map{(j) => 
+                            if(degeneracies.contains(j)) 
+                              DegenerateSimplicialSetElement(
+                                base, 
+                                degeneracies.collect {
+                                  case i if(i > j) => i-1
+                                  case i if (i < j) => i
+                                }
+                              )
+                            else SimplicialSetElement.empty
+                          }.toList
+                      case sse if(quotientGenerators.contains(sse)) =>
+                        if (!collapseMap.keySet.contains(sse))
+                          (0 to sse.dim).map(superSet.face(_)(sse)).toList
+                        else (0 to sse.dim).map{(_) => SimplicialSetElement.empty}.toList
+                    }),
+      superSet,
+      projection
+      )
+  }
 }
 
 /** The Pushout of a diagram
@@ -597,27 +694,26 @@ case class Pushout(
                     left: SimplicialSet, center: SimplicialSet, right: SimplicialSet,
                     f: PartialFunction[SimplicialSetElement, SimplicialSetElement],
                     g: PartialFunction[SimplicialSetElement, SimplicialSetElement]
-                   ) extends SimplicialSet {
+                  ) extends SimplicialSet {
   lazy val ambient: Product = Product(left, right)
-  lazy val ambient_ssl : SimplicialSet = ambient
+  lazy val ambient_ssl: SimplicialSet = ambient
 
   override def generators: Seq[SimplicialSetElement] =
     for
       psse <- ambient.generators
       p = psse.asInstanceOf[ProductElement] // this is ugly, but I'm stuck
-      if(f(p.left) == g(p.right))
+      if (f(p.left) == g(p.right))
     yield
       p
 
-  override def face(index: Int): PartialFunction[SimplicialSetElement, SimplicialSetElement] =
-    {
-      case ProductElement(leftS, rightS) => ProductElement(left.face(index)(leftS), right.face(index)(rightS))
-    }
+  override def face(index: Int): PartialFunction[SimplicialSetElement, SimplicialSetElement] = {
+    case ProductElement(leftS, rightS) => ProductElement(left.face(index)(leftS), right.face(index)(rightS))
+  }
 }
 
 
 /** ************** Examples
-  */
+ */
 
 def sphere(dim: Int): SimplicialSet = {
   val v0 = simplicialGenerator(0)

--- a/src/main/scala/org/appliedtopology/tda4j/SymmetryGroup.scala
+++ b/src/main/scala/org/appliedtopology/tda4j/SymmetryGroup.scala
@@ -7,7 +7,7 @@ import java.util.NoSuchElementException
 import scala.collection.mutable.ListBuffer
 import org.apache.commons.numbers.combinatorics.Factorial
 
-import scala.collection.parallel.CollectionConverters._
+import scala.collection.parallel.CollectionConverters.*
 import scala.concurrent.{Await, Future}
 import scala.concurrent.duration.Duration
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -399,7 +399,7 @@ class Permutations(elementCount: Int) {
     *   Image of the permutation as a [[List]].
     */
   def apply(n: Int): List[Int] = {
-    val source: ListBuffer[Int] = ListBuffer(Range(0, elementCount).toList: _*)
+    val source: ListBuffer[Int] = ListBuffer(Range(0, elementCount).toList*)
     val retval: ListBuffer[Int] = ListBuffer[Int]()
 
     var pos: Long = n.toLong

--- a/src/main/scala/org/appliedtopology/tda4j/VietorisRips.scala
+++ b/src/main/scala/org/appliedtopology/tda4j/VietorisRips.scala
@@ -27,7 +27,7 @@ class VietorisRips[VertexT](using ordering: Ordering[VertexT])(
   val metricSpace: FiniteMetricSpace[VertexT],
   val maxFiltrationValue: Double = Double.PositiveInfinity,
   val maxDimension: Int = 2,
-  val cliqueFinder: CliqueFinder[VertexT] = new ZomorodianIncremental[VertexT]()(ordering)
+  val cliqueFinder: CliqueFinder[VertexT] = new ZomorodianIncremental[VertexT](using ordering)
 ) extends SimplexStream[VertexT, Double] {
   self =>
 
@@ -305,8 +305,8 @@ object LazyVietorisRips {
 
         val newSimplices: SortedSet[Simplex[VertexT]] =
           V.map(spx => spx.vertices)
-           .map(spx => Simplex.from(spx ++ endpoints))
-           .to(SortedSet)
+            .map(spx => Simplex.from(spx ++ endpoints))
+            .to(SortedSet)
 
         FoldState(
           g + nextEdge,
@@ -400,10 +400,11 @@ object LazyStratifiedVietorisRips {
     )
     @tailrec def oneStep(foldState: FoldState): Array[LazyList[Simplex[VertexT]]] =
       if (foldState.taskStack.isEmpty) foldState.outputLists
-      else if (foldState.taskStack.head._1.dim > maxSize-1) oneStep(foldState.copy(taskStack = foldState.taskStack.tail))
+      else if (foldState.taskStack.head._1.dim > maxSize - 1)
+        oneStep(foldState.copy(taskStack = foldState.taskStack.tail))
       else {
         val (simplex, edge) = foldState.taskStack.head
-        val List(src, tgt) : List[VertexT] = List(edge._1,edge._2).sorted // ensure src < tgt
+        val List(src, tgt): List[VertexT] = List(edge._1, edge._2).sorted // ensure src < tgt
         val neighbors: Map[VertexT, Set[VertexT]] = if (simplex.dim == 1) { // new edge enters
           foldState.neighbors
             .updated(tgt, foldState.neighbors.getOrElse(tgt, Set()) + src)
@@ -416,7 +417,7 @@ object LazyStratifiedVietorisRips {
           for
             cofacet <- candidateCofacets
             others = cofacet.vertices.toList
-              .combinations(simplex.dim+1)
+              .combinations(simplex.dim + 1)
               .filter(spx => filtrationValue(Simplex.from(spx)) == metricSpace.distance(src, tgt))
               .toList
               .sorted(math.Ordering.Implicits.seqOrdering)

--- a/src/main/scala/org/appliedtopology/tda4j/VietorisRips.scala
+++ b/src/main/scala/org/appliedtopology/tda4j/VietorisRips.scala
@@ -189,7 +189,7 @@ class BronKerbosch[VertexT: Ordering] extends CliqueFinder[VertexT] {
     val simplices: Seq[Simplex[VertexT]] =
       cliqueSet
         .filter(spx => spx.nonEmpty)
-        .map(spx => Simplex[VertexT](spx.to(Seq): _*)) to Seq
+        .map(spx => Simplex[VertexT](spx.to(Seq)*)) to Seq
     val filtration =
       new MaximumDistanceFiltrationValue[VertexT](metricSpace)
     val simplexOrdering =
@@ -286,7 +286,7 @@ object LazyVietorisRips {
 
         val V = mutable.SortedSet[Simplex[VertexT]]()
         val tasks = mutable.Stack[(SortedSet[VertexT], SortedSet[VertexT])](
-          (SortedSet[VertexT](endpoints: _*), neighbors.reduce(_ & _))
+          (SortedSet[VertexT](endpoints*), neighbors.reduce(_ & _))
         )
 
         while (tasks.nonEmpty) {

--- a/src/test/scala/org/appliedtopology/tda4j/ChainSpec.scala
+++ b/src/test/scala/org/appliedtopology/tda4j/ChainSpec.scala
@@ -178,7 +178,7 @@ class HeapChainSpec extends mutable.Specification {
     }
     "be created from varargs" >> {
       val elts = Seq((∆(1, 2), 1.0), (∆(1, 3), -1.0))
-      val hc = Chain[Simplex[Int], Double](elts: _*)
+      val hc = Chain[Simplex[Int], Double](elts*)
       "contains the right things" ==>
         (hc.items.toList must containTheSameElementsAs(elts))
     }

--- a/src/test/scala/org/appliedtopology/tda4j/FiniteFieldSpec.scala
+++ b/src/test/scala/org/appliedtopology/tda4j/FiniteFieldSpec.scala
@@ -5,9 +5,9 @@ import org.specs2.execute.{AsResult, Result}
 import org.specs2.ScalaCheck
 
 import scala.util.Random
-import scala.math.Fractional.Implicits._
+import scala.math.Fractional.Implicits.*
 
-import org.scalacheck._
+import org.scalacheck.*
 
 //noinspection ScalaRedundantConversion
 object FiniteFieldSpec extends mutable.Specification with ScalaCheck {

--- a/src/test/scala/org/appliedtopology/tda4j/SimplicialSetSpec.scala
+++ b/src/test/scala/org/appliedtopology/tda4j/SimplicialSetSpec.scala
@@ -49,22 +49,4 @@ class SimplicialSetSpec extends mutable.Specification {
       (2, 2.0, Double.PositiveInfinity), // essential 2-class
     ))
   }
-  
-  "product of two spheres - specific failure example" >> {
-    val ss = Product(sphere(6), sphere(7))
-    val forbidden = ss
-      .generators
-      .filter(_.dim == 9)
-      .filter{(sse) => sse.asInstanceOf[SimplicialWrapper[ProductElement]].wrapped.left.degeneracies == List(5,2,1)}
-      .filter{(sse) => sse.asInstanceOf[SimplicialWrapper[ProductElement]].wrapped.right.degeneracies == List(3,0)}
-    
-    val required = ss
-      .generators
-      .filter(_.dim == 9)
-      .filter { (sse) => sse.asInstanceOf[SimplicialWrapper[ProductElement]].wrapped.left.degeneracies == List(5, 1, 0) }
-      .filter { (sse) => sse.asInstanceOf[SimplicialWrapper[ProductElement]].wrapped.right.degeneracies == List(3, 0) }
-
-    "s₅ s₂ s₁ ∆⁶ x s₃ s₀ ∆⁷ = s₃ ( s₅ s₁ ∆⁶ x s₀ ∆⁷) is degenerate" ==> (forbidden.isEmpty must beTrue)
-    "s₅ s₁ s₀ ∆⁶ x s₃ s₀ ∆⁷ is non-degenerate" ==> (required.nonEmpty must beTrue)
-  }
 }

--- a/src/test/scala/org/appliedtopology/tda4j/SimplicialSetSpec.scala
+++ b/src/test/scala/org/appliedtopology/tda4j/SimplicialSetSpec.scala
@@ -1,5 +1,6 @@
 package org.appliedtopology.tda4j
 
+import org.appliedtopology.tda4j.SimplicialSetExamples.sphere
 import org.specs2.mutable
 
 class SimplicialSetSpec extends mutable.Specification {


### PR DESCRIPTION
Moved Scala minor version up to 3.5, and enabled `-source:future` and `-language:experimental.modularity` to prepare for the change in given resolution announced to be phased in by 3.7, and to enable to new syntax for type classes.